### PR TITLE
feat: 多个 pre handler 支持

### DIFF
--- a/frame/gateway/gateway.go
+++ b/frame/gateway/gateway.go
@@ -89,9 +89,10 @@ type HandlerInfo struct {
 	// 接口签名验证时间的有效时间长度
 	expire time.Duration
 
-	// preHandler 在业务Handler 处理前，定义的预处理
-	preHandler PreHandler
-	pt         paramType
+	// preHandlers 在业务Handler 处理前，定义的预处理
+	preHandlers []PreHandler
+
+	pt          paramType
 }
 
 type FieldInfo struct {

--- a/frame/gateway/middle.go
+++ b/frame/gateway/middle.go
@@ -102,19 +102,22 @@ func handlerApiRequest(c *gin.Context) {
 	if apiHandlerInfo.pt == formType {
 		err = c.ShouldBindQuery(request)
 	} else {
-		if apiHandlerInfo.preHandler != nil {
+		if len(apiHandlerInfo.preHandlers) != 0 {
 			err = c.ShouldBindBodyWith(request, binding.JSON)
 		} else {
 			err = c.BindJSON(request)
 		}
 	}
 
-	if apiHandlerInfo.preHandler != nil {
+	if len(apiHandlerInfo.preHandlers) != 0 {
 		apiContext.Keys = make(map[string]interface{}, 4)
-		resp := apiHandlerInfo.preHandler(c, apiContext)
-		if resp != nil && resp.Code != 0 {
-			failHanler(c, http.StatusOK, resp.Code, resp.Message)
-			return
+
+		for _, handler := range apiHandlerInfo.preHandlers {
+			resp := handler(c, apiContext)
+			if resp != nil && resp.Code != 0 {
+				failHanler(c, http.StatusOK, resp.Code, resp.Message)
+				return
+			}
 		}
 	}
 

--- a/frame/gateway/option.go
+++ b/frame/gateway/option.go
@@ -26,7 +26,7 @@ func Expired(duration time.Duration) Option {
 // HandlerFunc 设置 PreHandler，可用于统一登录鉴权使用
 func HandlerFunc(handlerFunc PreHandler) Option {
 	return optionFunc(func(handler *HandlerInfo) {
-		handler.preHandler = handlerFunc
+		handler.preHandlers = append(handler.preHandlers, handlerFunc)
 	})
 }
 

--- a/main.go
+++ b/main.go
@@ -2,39 +2,79 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gin-gonic/gin"
+
 	"github.com/xbonlinenet/goup/demo"
 	"github.com/xbonlinenet/goup/frame"
 	"github.com/xbonlinenet/goup/frame/gateway"
+	"github.com/xbonlinenet/goup/frame/log"
 )
 
 func main() {
 	ctx := context.Background()
-	frame.BootstrapServer(ctx, frame.BeforeServerRun(registerRounter), frame.Version(version), frame.CustomRouter(customRounter), frame.ReportApi("http://192.168.0.22:14000/api/doc/report"))
+	frame.BootstrapServer(
+		ctx,
+		frame.BeforeServerRun(registerRouter),
+		frame.Version(version),
+		frame.CustomRouter(customRouter),
+		frame.ReportApi("http://192.168.0.22:14000/api/doc/report"),
+	)
 }
 
 func version(c *gin.Context) {
 
 }
 
-func customRounter(r *gin.Engine) {
+func customRouter(r *gin.Engine) {
 	r.GET("hello", func(c *gin.Context) {
 		c.String(200, "Hello world!")
 	})
 }
 
-func registerRounter() {
+func registerRouter() {
 	gateway.RegisterAPI("demo", "echo", "Demo for echo", demo.EchoHandler{})
 	gateway.RegisterAPI("demo", "redis", "Demo for reids incr", demo.RedisHandler{})
 	gateway.RegisterAPI("demo", "mysql", "Demo for mysql ", demo.MysqlHandler{})
 	gateway.RegisterAPI("demo", "config", "Demo for config center ", demo.ConfigHandler{})
-	gateway.RegisterAPI("demo", "pre", "Demo for pre handler, normally used in login filter", demo.PreHandler{}, gateway.HandlerFunc(demoPreHandler))
+	gateway.RegisterAPI("demo", "pre", "Demo for pre handler, normally used in login filter",
+		demo.PreHandler{},
+		gateway.HandlerFunc(demoPreHandler),
+		gateway.HandlerFunc(demoPreHandler2),
+		gateway.HandlerFunc(demoPreHandler3),
+	)
 	gateway.RegisterAPI("demo", "sleep", "Demo for sleep", demo.SleepHandler{})
 	gateway.RegisterAPI("demo", "doc", "Demo complex sturct", demo.DocHandler{})
 }
 
 func demoPreHandler(c *gin.Context, ctx *gateway.ApiContext) *gateway.Resp {
+	log.Default().Info("into demoPreHandler")
+
 	ctx.Keys["message"] = "This has handled by demoPreHandler"
+	return nil
+}
+
+func demoPreHandler2(c *gin.Context, ctx *gateway.ApiContext) *gateway.Resp {
+	log.Default().Info("into demoPreHandler2")
+
+	if _, ok := ctx.Keys["message"]; ok {
+		message := ctx.Keys["message"].(string)
+		newMsg := fmt.Sprintf("%s\nalso has handled by demoPreHandler2", message)
+		ctx.Keys["message"] = newMsg
+	}
+
+	return nil
+}
+
+func demoPreHandler3(c *gin.Context, ctx *gateway.ApiContext) *gateway.Resp {
+	log.Default().Info("into demoPreHandler3")
+
+	if _, ok := ctx.Keys["message"]; ok {
+		message := ctx.Keys["message"].(string)
+		newMsg := fmt.Sprintf("%s\nhandled by demoPreHandler3 too", message)
+		ctx.Keys["message"] = newMsg
+	}
+
 	return nil
 }


### PR DESCRIPTION
# 单个 pre handler 测试

直接启动服务，请求 `/api/demo/pre` 接口：

```json
{
  "code": 0,
  "message": "This has handled by demoPreHandler"
}
```

# 多个 pre handler 测试

修改 `main.go` 在文件下方增加修改:

```go
func demoPreHandler(c *gin.Context, ctx *gateway.ApiContext) *gateway.Resp {
	log.Default().Info("into demoPreHandler")

	ctx.Keys["message"] = "This has handled by demoPreHandler"
	return nil
}

func demoPreHandler2(c *gin.Context, ctx *gateway.ApiContext) *gateway.Resp {
	log.Default().Info("into demoPreHandler2")

	if _, ok := ctx.Keys["message"]; ok {
		message := ctx.Keys["message"].(string)
		newMsg := fmt.Sprintf("%s\nalso has handled by demoPreHandler2", message)
		ctx.Keys["message"] = newMsg
	}

	return nil
}

func demoPreHandler3(c *gin.Context, ctx *gateway.ApiContext) *gateway.Resp {
	log.Default().Info("into demoPreHandler3")

	if _, ok := ctx.Keys["message"]; ok {
		message := ctx.Keys["message"].(string)
		newMsg := fmt.Sprintf("%s\nhandled by demoPreHandler3 too", message)
		ctx.Keys["message"] = newMsg
	}

	return nil
}
```

修改注册路由处，增加多个 pre handler:

```go
	gateway.RegisterAPI("demo", "pre", "Demo for pre handler, normally used in login filter",
		demo.PreHandler{},
		gateway.HandlerFunc(demoPreHandler),
		gateway.HandlerFunc(demoPreHandler2),
		gateway.HandlerFunc(demoPreHandler3),
	)
```

启动服务，再次请求测试接口：

```json
{
  "code": 0,
  "message": "This has handled by demoPreHandler\nalso has handled by demoPreHandler2\nhandled by demoPreHandler3 too"
}
```

日志打印：

```
1.588734392487257e+09	info	goup/main.go:52	into demoPreHandler
1.588734392487285e+09	info	goup/main.go:59	into demoPreHandler2
1.588734392487297e+09	info	goup/main.go:71	into demoPreHandler3
```
