### PR TITLE
CORS 处理 & 支持自定义响应 Headers

### DIFF
--- a/demo/echo.go
+++ b/demo/echo.go
@@ -22,6 +22,8 @@ func (h EchoHandler) Mock() interface{} {
 	return EchoResponse{Code: 0, Message: "Mock Response"}
 
 }
+
 func (h EchoHandler) Handler(c *gateway.ApiContext) (interface{}, error) {
+	c.WriteHeader("X-Message", h.Request.Message)
 	return &EchoResponse{Code: 0, Message: h.Request.Message}, nil
 }

--- a/frame/gateway/cors_option.go
+++ b/frame/gateway/cors_option.go
@@ -1,0 +1,76 @@
+package gateway
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	"github.com/xbonlinenet/goup/frame/log"
+)
+
+type CORSHandler struct {
+	AllowHosts []string
+}
+
+func NewCORSHandler(allowHosts []string) *CORSHandler {
+	return &CORSHandler{
+		AllowHosts: allowHosts,
+	}
+}
+
+func (h *CORSHandler) CheckOriginByRequest(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	return h.CheckOrigin(origin)
+}
+
+func (h *CORSHandler) CheckOrigin(origin string) bool {
+	if origin == "" {
+		// 非浏览器请求
+		return false
+	}
+
+	originURL, err := url.Parse(origin)
+	if err != nil {
+		log.Default().Warn("ParseOriginErr", zap.Error(err))
+		return false
+	}
+
+	var isAllow bool
+	for _, allowHost := range h.AllowHosts {
+		if originURL.Host == allowHost {
+			isAllow = true
+			break
+		}
+	}
+
+	return isAllow
+}
+
+func (h *CORSHandler) BuildCORSHeaders(r *http.Request) map[string]string {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		origin = "*"
+	}
+
+	headers := map[string]string{
+		"Access-Control-Allow-Credentials": "true",
+		"Access-Control-Allow-Methods":     "GET,HEAD,POST,PUT,DELETE",
+		"Access-Control-Allow-Origin":      origin,
+	}
+	return headers
+}
+
+func (h *CORSHandler) WriteCORSHeader(ctx *gin.Context) {
+	headers := h.BuildCORSHeaders(ctx.Request)
+	for key, val := range headers {
+		ctx.Header(key, val)
+	}
+}
+
+func WithCORSHandler(h *CORSHandler) Option {
+	return optionFunc(func(handler *HandlerInfo) {
+		handler.corsHandler = h
+	})
+}

--- a/frame/gateway/cors_option.go
+++ b/frame/gateway/cors_option.go
@@ -12,11 +12,22 @@ import (
 
 type CORSHandler struct {
 	AllowHosts []string
+	AllowAll   bool
 }
 
 func NewCORSHandler(allowHosts []string) *CORSHandler {
+	var allowAll bool
+
+	for _, host := range allowHosts {
+		if host == "*" {
+			allowAll = true
+			break
+		}
+	}
+
 	return &CORSHandler{
 		AllowHosts: allowHosts,
+		AllowAll:   allowAll,
 	}
 }
 
@@ -29,6 +40,10 @@ func (h *CORSHandler) CheckOrigin(origin string) bool {
 	if origin == "" {
 		// 非浏览器请求
 		return false
+	}
+
+	if h.AllowAll {
+		return true
 	}
 
 	originURL, err := url.Parse(origin)

--- a/frame/gateway/gateway.go
+++ b/frame/gateway/gateway.go
@@ -62,6 +62,15 @@ type ApiContext struct {
 	APIConfig struct {
 		Expires time.Duration
 	} `json:"-"`
+
+	// response headers
+	respHeaders map[string]string `json:"-"`
+}
+
+func (c *ApiContext) WriteHeader(key, val string) {
+	if c.respHeaders != nil {
+		c.respHeaders[key] = val
+	}
 }
 
 type Handler interface {
@@ -89,10 +98,13 @@ type HandlerInfo struct {
 	// 接口签名验证时间的有效时间长度
 	expire time.Duration
 
+	pt paramType
+
 	// preHandlers 在业务Handler 处理前，定义的预处理
 	preHandlers []PreHandler
 
-	pt          paramType
+	// CORS 处理器
+	corsHandler *CORSHandler
 }
 
 type FieldInfo struct {

--- a/frame/gateway/option.go
+++ b/frame/gateway/option.go
@@ -23,7 +23,7 @@ func Expired(duration time.Duration) Option {
 	})
 }
 
-// HandlerFunc 设置 PreHandler，可用于统一登录鉴权使用
+// HandlerFunc 设置 WriteCORSHeader，可用于统一登录鉴权使用
 func HandlerFunc(handlerFunc PreHandler) Option {
 	return optionFunc(func(handler *HandlerInfo) {
 		handler.preHandlers = append(handler.preHandlers, handlerFunc)
@@ -35,3 +35,4 @@ func FormParam() Option {
 		handler.pt = formType
 	})
 }
+

--- a/frame/xrpc/http.go
+++ b/frame/xrpc/http.go
@@ -33,6 +33,7 @@ const (
 	DefaultTimeout = 10 * time.Second
 )
 
+// RequestOptions 请求设置
 type RequestOptions struct {
 	// 超时时间
 	Timeout time.Duration
@@ -91,6 +92,9 @@ func initHttpClient() {
 
 var Json = jsoniter.ConfigCompatibleWithStandardLibrary
 
+// HttpPostWithOptions
+//     headers := map[string]string{"X-Key": "val"}
+//     respBytes, err := HttpPostWithOptions(ctx, url, data, WithTimeout(10*time.Second), WithHeaders(headers))
 func HttpPostWithOptions(
 	c *gateway.ApiContext, url string, data interface{}, options ...RequestOption) ([]byte, error) {
 

--- a/main.go
+++ b/main.go
@@ -34,7 +34,13 @@ func customRouter(r *gin.Engine) {
 }
 
 func registerRouter() {
+	ilikeCORSHandler := gateway.NewCORSHandler([]string{"www.ilikee.vn", "ilikee.vn", "0.0.0.0:8000"})
+
 	gateway.RegisterAPI("demo", "echo", "Demo for echo", demo.EchoHandler{})
+	gateway.RegisterAPI("demo", "cors_echo", "Demo for cors",
+		demo.EchoHandler{},
+		gateway.WithCORSHandler(ilikeCORSHandler),
+	)
 	gateway.RegisterAPI("demo", "redis", "Demo for reids incr", demo.RedisHandler{})
 	gateway.RegisterAPI("demo", "mysql", "Demo for mysql ", demo.MysqlHandler{})
 	gateway.RegisterAPI("demo", "config", "Demo for config center ", demo.ConfigHandler{})


### PR DESCRIPTION
## Test CORS With Chrome

增加 CORS 处理器，并在注册 API 的时候使用：

```go
ilikeCORSHandler := gateway.NewCORSHandler([]string{"www.ilikee.vn", "ilikee.vn", "0.0.0.0:8000"})
gateway.RegisterAPI("demo", "cors_echo", "Demo for cors",
	demo.EchoHandler{},
	gateway.WithCORSHandler(ilikeCORSHandler),
)
```

HTML:

```
<!DOCTYPE html>
<html>

<head>
    <meta charset="utf-8">
    <title>Test</title>
</head>

<body>
    <script src="index.js"></script>
</body>

</html>
```

 JS 请求代码：

```js
var req = new XMLHttpRequest();

req.addEventListener('load', function (resp) {
    console.log(resp);
})

var body = JSON.stringify({
    'message': '10',
})

req.open("POST", "http://localhost:13360/api/demo/cors_echo")
req.send(body);
```

启动 Web 服务并访问页面：

```
➜ python -m http.server
Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
```

Request Headers:

```
POST /api/demo/cors_echo HTTP/1.1
Host: localhost:13360
Connection: keep-alive
Content-Length: 16
Pragma: no-cache
Cache-Control: no-cache
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.44 Safari/537.36
Content-Type: text/plain;charset=UTF-8
Accept: */*
Origin: http://0.0.0.0:8000
Sec-Fetch-Site: cross-site
Sec-Fetch-Mode: cors
Sec-Fetch-Dest: empty
Referer: http://0.0.0.0:8000/
Accept-Encoding: gzip, deflate, br
Accept-Language: zh-CN,zh;q=0.9,en;q=0.8
```

Response Headers:

```
HTTP/1.1 200 OK
Access-Control-Allow-Credentials: true
Access-Control-Allow-Methods: GET,HEAD,POST,PUT,DELETE
Access-Control-Allow-Origin: http://0.0.0.0:8000
Content-Type: application/json; charset=utf-8
Date: Tue, 12 May 2020 02:55:13 GMT
Content-Length: 26
```

## 自定义 Headers

修改 EchoHandler:

```go
func (h EchoHandler) Handler(c *gateway.ApiContext) (interface{}, error) {
	c.WriteHeader("X-Message", h.Request.Message)
	return &EchoResponse{Code: 0, Message: h.Request.Message}, nil
}
```

启动并请求:

```
➜ curl --request \
  --url http://localhost:13360/api/demo/echo \
  --header 'content-type: application/json' \
  --data '{
        "message": "test"
}' -v
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 13360 (#0)
> --url /api/demo/echo HTTP/1.1
> Host: localhost:13360
> User-Agent: curl/7.59.0
> Accept: */*
> content-type: application/json
> Content-Length: 22
>
* upload completely sent off: 22 out of 22 bytes
< HTTP/1.1 200 OK
< Content-Type: application/json; charset=utf-8
< X-Message: test
< Date: Tue, 12 May 2020 02:59:17 GMT
< Content-Length: 28
<
{"code":0,"message":"test"}
```