### PR TITLE
support more resp content-type

### DIFF
--- a/demo/react.go
+++ b/demo/react.go
@@ -1,0 +1,85 @@
+package demo
+
+import (
+	"github.com/xbonlinenet/goup/frame/gateway"
+)
+
+// ReactRequest ...
+type ReactRequest struct {
+	RespType int `json:"resp_type"`
+}
+
+type ReactResponse struct {
+	Code    int    `json:"code" desc:"0: success other: fail"`
+	Message string `json:"message" desc:"message get from api context" `
+}
+
+type ReactHandler struct {
+	Request  ReactRequest
+	Response ReactResponse
+}
+
+func (h ReactHandler) Mock() interface{} {
+	return ReactResponse{Code: 0, Message: "Hello world"}
+
+}
+
+// Handler ....
+func (h ReactHandler) Handler(c *gateway.ApiContext) (interface{}, error) {
+
+	switch h.Request.RespType {
+	case int(gateway.TextHtmlType):
+		return h.GetTextHTML(), nil
+	case int(gateway.OctetStreamType):
+		return h.GetOctetStream(), nil
+	case int(gateway.JsonStreamType):
+		return h.GetJsonStream(), nil
+	default:
+		return h.GetDefault(), nil
+	}
+}
+
+func (h ReactHandler) GetDefault() interface{} {
+	str := struct {
+		Key string `json:"key"`
+		Tag string `json:"tag"`
+	}{Key: "localhost", Tag: "advert"}
+	return str
+}
+
+// GetTextHTML ...
+func (h ReactHandler) GetTextHTML() []byte {
+	data := `<!DOCTYPE html>
+           <html lang="en">
+           <head>
+               <meta charset="UTF-8">
+               <meta http-equiv="X-UA-Compatible" content="IE=edge">
+               <meta name="viewport" content="width=device-width, initial-scale=1.0">
+               <title>Document</title>
+           </head>
+           <body>
+               Hello world
+           </body>
+           </html>`
+	return []byte(data)
+}
+
+// GetOctetStream ...
+func (h ReactHandler) GetOctetStream() []byte {
+
+	return []byte("hello world")
+
+}
+
+// GetJsonStream ...
+func (h ReactHandler) GetJsonStream() []byte {
+
+	data := `
+       {
+         "html":"Success<br>",
+         "address":"127.0.0.1"
+           }
+        `
+	return []byte(data)
+
+}

--- a/frame/gateway/gateway.go
+++ b/frame/gateway/gateway.go
@@ -97,9 +97,12 @@ const (
 type respType int
 
 const (
-	JsonType   respType = 0
-	XmlType    respType = 1
-	StringType respType = 2
+	JsonType respType = iota
+	XmlType
+	StringType
+	TextHtmlType
+	OctetStreamType
+	JsonStreamType
 )
 
 type HandlerInfo struct {

--- a/frame/gateway/option.go
+++ b/frame/gateway/option.go
@@ -48,6 +48,13 @@ func ResponseString() Option {
 	})
 }
 
+// RespContentType 指定响应类型，传入定义的常量
+func RespContentType(contentType respType) Option {
+	return optionFunc(func(handler *HandlerInfo) {
+		handler.respType = contentType
+	})
+}
+
 // ExtInfo 设置额外的说明信息
 func ExtInfo(info map[string]string) Option {
 	return optionFunc(func(handler *HandlerInfo) {

--- a/main.go
+++ b/main.go
@@ -95,6 +95,8 @@ func registerRouter() {
 	)
 	gateway.RegisterAPI("demo", "sleep", "Demo for sleep", demo.SleepHandler{})
 	gateway.RegisterAPI("demo", "doc", "Demo complex sturct", demo.DocHandler{})
+	gateway.RegisterAPI("demo", "reactHtml", "Demo test for react", demo.ReactHandler{},
+		gateway.RespContentType(gateway.TextHtmlType))
 }
 
 func demoPreHandler(c *gin.Context, ctx *gateway.ApiContext) *gateway.Resp {


### PR DESCRIPTION
1.之前默认响应为c.PureJSON(200, response)。当响应内容为[]byte时，会编码成base64字符串。
2.添加自定义Option，响应时支持更多的content-type。比如text/html、octet/stream等。